### PR TITLE
Remove table from database before scraping

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -14,7 +14,7 @@ def noko(url)
   Nokogiri::HTML(open(url).read)
 end
 
-ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
+ScraperWiki.sqliteexecute('DROP TABLE data') rescue nil
 
 BASE = 'http://www.parliament.gov.bw/component/member/'
 url = BASE + '?action=showAll&Itemid=110&limit=500'


### PR DESCRIPTION
SqliteMagic creates a unique index at CREATE TABLE time. This means that if the unique index arguments of ScraperWiki.save_sqlite, we need to create a new table to ensure the db reflects the change.

Part of: https://github.com/everypolitician/everypolitician/issues/593